### PR TITLE
fix assertion on test when faker returns apostrophe in company name

### DIFF
--- a/tests/Cleaner/FieldCleaner/FakerTest.php
+++ b/tests/Cleaner/FieldCleaner/FakerTest.php
@@ -24,6 +24,6 @@ class FakerTest extends TestCase
 
         $result = $cleaner->clean(['company']);
 
-        $this->assertMatchesRegularExpression("/^[a-zA-Z\ \.\,\-]+$/", $result);
+        $this->assertMatchesRegularExpression("/^[a-zA-Z\ \.\,\-\']+$/", $result);
     }
 }


### PR DESCRIPTION
Currently (with faker hard-required), the test on the fieldcleaner sometimes fails. This is triggered when `faker` generates a company name with an apostrophe in it. This updates the regex to allow apostrophes in the company name pattern.