### PR TITLE
Shift PHPUnit into a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "doctrine/dbal": "^2.5",
         "fakerphp/faker": "^1.13",
         "monolog/monolog": "^1.22||^2.0.0",
-        "phpunit/phpunit": "^9",
         "pimple/pimple": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
+        "phpunit/phpunit": "^9",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^2.7"
     },


### PR DESCRIPTION
Looks like this was accidental in https://github.com/nealio82/dbsampler/commit/794f4c51708b8f7cd0f3d0f03e894428963d69d3 

Breaking an upgrade on version conflicts downstream.